### PR TITLE
ci: fix would clobber existing tag error

### DIFF
--- a/.github/workflows/deploy-action.yml
+++ b/.github/workflows/deploy-action.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      # Fixes: https://github.com/semantic-release/git/issues/136
+      # because v1 tag in repo gets updated on each deployment. 
+      - name: Fix (would clobber existing tag)
+        run: git fetch -tp -f --all
       - name: Deploy via semantic release 
         uses: cycjimmy/semantic-release-action@v2
         with: 


### PR DESCRIPTION
Recently I got an error from semantic-release when trying to do a deployment:

```
[5:19:13 PM] [semantic-release] › ✖  An error occurred while running semantic-release: Error: Command failed with exit code 1: git fetch --tags https://x-access-token:[secure]@github.com/levibostian/action-sync-branches
From https://github.com/levibostian/action-sync-branches
 * branch            HEAD       -> FETCH_HEAD
 ! [rejected]        v1         -> v1  (would clobber existing tag)
```

This is very similar to the problem [this issue](https://github.com/semantic-release/git/issues/136) talks about. 

This pr tries to fix this issue by force fetching the latest tag. I want to try and continue updating the existing `v1` git tag for Actions. 